### PR TITLE
:sparkles: Feat: 로그인유지 기능 구현

### DIFF
--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -3,9 +3,17 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get/get.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  // 로그인 상태 확인
+  Future<bool> isLoggedIn() async {
+    final String? uid = await _storage.read(key: 'uid');
+    return uid != null && uid.isNotEmpty;
+  }
 
   Future<void> signInWithGoogle() async {
     try {
@@ -24,6 +32,9 @@ class AuthService {
       // 구글 로그인 성공시 UserCredential 반환
       await _auth.signInWithCredential(credential);
 
+      // uid 저장
+      await _storage.write(key: 'uid', value: _auth.currentUser?.uid);
+
       // 홈화면으로 이동
       Get.offAllNamed('/');
     } catch (error) {
@@ -34,5 +45,11 @@ class AuthService {
         snackPosition: SnackPosition.TOP,
       );
     }
+  }
+
+  // 로그아웃
+  Future<void> signOut() async {
+    await _auth.signOut();
+    await _storage.delete(key: 'uid');
   }
 }

--- a/lib/viewModels/auth/email_signup_viewmodel.dart
+++ b/lib/viewModels/auth/email_signup_viewmodel.dart
@@ -1,12 +1,14 @@
 import 'package:earlips/utilities/validators/auth_validators.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get/get.dart';
 
 class EmailSignupViewModel extends GetxController {
   final formKey = GlobalKey<FormState>();
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
   // Email Validator
   String? emailValidator(String? value) {
@@ -21,10 +23,16 @@ class EmailSignupViewModel extends GetxController {
   Future<void> registerWithEmailAndPassword() async {
     if (formKey.currentState!.validate()) {
       try {
-        await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        final UserCredential userCredential =
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
           email: emailController.text.trim(),
           password: passwordController.text.trim(),
         );
+
+        // uid 저장
+        final String uid = userCredential.user!.uid;
+        await _storage.write(key: 'uid', value: uid);
+
         // 뒤로
         Get.back();
       } on FirebaseAuthException catch (_) {

--- a/lib/views/auth/logout_dialog.dart
+++ b/lib/views/auth/logout_dialog.dart
@@ -1,39 +1,19 @@
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:earlips/services/auth/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 Future<void> showLogoutDialog(BuildContext context) async {
-  return showDialog<void>(
-    context: context,
-    barrierDismissible: false,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        title: const Text('로그아웃'),
-        content: const SingleChildScrollView(
-          child: ListBody(
-            children: <Widget>[
-              Text('정말 로그아웃하시겠습니까?'),
-            ],
-          ),
-        ),
-        actions: <Widget>[
-          TextButton(
-            child: const Text('취소'),
-            onPressed: () {
-              Get.back();
-            },
-          ),
-          TextButton(
-            child: const Text('로그아웃'),
-            onPressed: () async {
-              // 로그아웃 처리
-              // FirebaseAuth.instance.signOut();
-              await FirebaseAuth.instance.signOut();
-              Get.back();
-            },
-          ),
-        ],
-      );
+  final AuthService authService = AuthService();
+
+  return Get.defaultDialog(
+    title: '로그아웃',
+    content: const Text('정말 로그아웃하시겠습니까?'),
+    textConfirm: '로그아웃',
+    textCancel: '취소',
+    onCancel: () => Get.back(), // Equivalent to closing the dialog
+    onConfirm: () async {
+      await authService.signOut();
+      Get.back(); // Close the dialog after signOut
     },
   );
 }

--- a/lib/views/root/root_screen.dart
+++ b/lib/views/root/root_screen.dart
@@ -1,10 +1,8 @@
-import 'package:earlips/views/auth/login_screen.dart';
 import 'package:earlips/views/profile/profile_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:earlips/views/home/home_screen.dart';
 import 'package:earlips/views/root/custom_bottom_navigation_bar.dart';
-
 import '../../viewModels/root/root_viewmodel.dart';
 import '../base/base_screen.dart';
 


### PR DESCRIPTION
feat: 로그인유지 기능 구현
## ⛅️ 작업 내용

-   [x] get dialog 리펙토링
-   [x] 로그인 정보 기기값에 저장 
-   [x] 로그인/로그아웃 기기값 연결 

## 유저정보 이용하는 방법
``` dart 

  final User? user;
                user != null
                    ? Text("오늘도 이어립스 해볼까요, ${user!.email}")
                    : const Text(
                        "로그인 하러가기",
                        style: TextStyle(color: Colors.blue),
                      ),
``` 

예시)
``` dart
import 'package:earlips/views/auth/login_screen.dart';
import 'package:firebase_auth/firebase_auth.dart';
import 'package:flutter/material.dart';
import 'package:get/get.dart';

class ProfileHeader extends StatelessWidget {
  final User? user;

  const ProfileHeader({super.key, this.user});

  @override
  Widget build(BuildContext context) {
    return Container(
      color: Colors.white,
      child: GestureDetector(
        onTap: () => user != null ? null : Get.to(() => LoginScreen()),
        child: Container(
          color: Colors.white,
          child: Padding(
            padding: const EdgeInsets.fromLTRB(20, 62, 20, 24),
            child: Row(
              mainAxisAlignment: MainAxisAlignment.spaceBetween,
              children: [
                // 유저 정보가 있으면 이메일을 보여주고, 없으면 로그인 버튼 보여줌
                user != null
                    ? Text("오늘도 이어립스 해볼까요, ${user!.email}")
                    : const Text(
                        "로그인 하러가기",
                        style: TextStyle(color: Colors.blue),
                      ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}

```
